### PR TITLE
Update Berthe to 5.0, level up php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,14 +39,14 @@
     "config": {
         "bin-dir": "bin/",
         "platform": {
-            "php": "5.3.10"
+            "php": "5.5.30"
         }
     },
     "require": {
         "evaneos/translations": "~2.0",
         "evaneos/pyrite": "~4.0",
         "evaneos/trolamine": "~2.0",
-        "evaneos/berthe" : "~4.0",
+        "evaneos/berthe" : "~5.0",
         "monolog/monolog": "^1.13",
         "league/fractal": "~0.7.0",
         "twig/twig": "~1.18",

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,7 @@
         }
     ],
     "config": {
-        "bin-dir": "bin/",
-        "platform": {
-            "php": "5.5.30"
-        }
+        "bin-dir": "bin/"
     },
     "require": {
         "evaneos/translations": "~2.0",


### PR DESCRIPTION
I'm not sure php version constraint should be here. In my opinion this is a constraint of the application using the framework and should be placed in the other repo.
