### PR TITLE
FIX - storing translations in database always log an error

### DIFF
--- a/src/Translation/StringDatabaseEngine.php
+++ b/src/Translation/StringDatabaseEngine.php
@@ -121,6 +121,8 @@ SQL;
         } catch (\Exception $e) {
             throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
+
+        return true;
     }
 
     public function deleteKeys($keys)


### PR DESCRIPTION
Update set on StringDatabaseEngine to return true. It is used in Translation_Manager, and the expected result should be a boolean, if it's false, it log an error. But instead StringDatabaseEngine returned nothing (null), so I change it to return true
