### PR TITLE
Use v5.0.0 of evaneos/pyrite framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require": {
         "evaneos/translations": "~2.0",
-        "evaneos/pyrite": "~4.0",
+        "evaneos/pyrite": "^5.0.0",
         "evaneos/trolamine": "~2.0",
         "evaneos/berthe" : "~5.0 || ^6.0",
         "monolog/monolog": "^1.13",


### PR DESCRIPTION
In order to be able to update this dependency in another application.

A simple research showed that [the breaking change introduced in the v5](https://github.com/Evaneos/pyrite/releases/tag/v5.0.0) does not break anything here.